### PR TITLE
Update README.md on using HTTPS links for cloning

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ git submodule update
 NOTE: `git submodule update` clones using SSH links. If you are having trouble with the command manually - e.g. you haven't set-up SSH keys in your GitHub account - clone using HTTPS links:
 ```
 git clone https://github.com/OpenUnited/product-factory-backend.git backend
-git clone https://github.com/OpenUnited/product-factory-frontend/tree/b0b5fafd1758647c73debf82d424f2ed603188d9 frontend
+git clone https://github.com/OpenUnited/product-factory-frontend.git frontend
 ```
 
 2. Create backend/.env file from backend/.env.template and update the file variables with your information.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ git submodule init
 git submodule update
 ```
 
+NOTE: `git submodule update` clones using SSH links. If you are having trouble with the command manually - e.g. you haven't set-up SSH keys in your GitHub account - clone using HTTPS links:
+```
+git clone https://github.com/OpenUnited/product-factory-backend.git backend
+git clone https://github.com/OpenUnited/product-factory-frontend/tree/b0b5fafd1758647c73debf82d424f2ed603188d9 frontend
+```
+
 2. Create backend/.env file from backend/.env.template and update the file variables with your information.
 ```
 cp backend/.env.template backend/.env

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ git submodule init
 git submodule update
 ```
 
-NOTE: `git submodule update` clones using SSH links. If you are having trouble with the command manually - e.g. you haven't set-up SSH keys in your GitHub account - clone using HTTPS links:
+NOTE: `git submodule update` clones using SSH links. If you are having trouble with the command manually - e.g. you haven't [set-up SSH keys](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account) in your GitHub account - clone using HTTPS links:
 ```
 git clone https://github.com/OpenUnited/product-factory-backend.git backend
 git clone https://github.com/OpenUnited/product-factory-frontend.git frontend


### PR DESCRIPTION
The git submodules use SSH git links, which is great, however it fails when the user hasn't added SSH keys.

This change adds a NOTE for users which have not yet set that up.